### PR TITLE
feat: support multiple databases via @DaoQueryDataSource qualifier (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Inspired by and forked from [`gasparbarancelli/spring-native-query`](https://git
 - [Pagination](#pagination)
 - [Dynamic filtering](#dynamic-filtering)
 - [JdbcTemplate vs EntityManager](#jdbctemplate-vs-entitymanager)
+- [Multiple databases](#multiple-databases)
 - [Handlebars helpers](#handlebars-helpers)
 - [Kotlin support](#kotlin-support)
 - [Enum conversion](#enum-conversion)
@@ -282,6 +283,47 @@ public class UserTO {
 public class UserTOMapper implements RowMapper<UserTO> { /* … */ }
 ```
 
+## Multiple databases
+
+To talk to more than one database from the same application, declare each datasource (and its `EntityManager` / `NamedParameterJdbcTemplate`) with a Spring `@Qualifier`, then tag the DAO interface with `@DaoQueryDataSource("name")` matching that qualifier:
+
+```java
+@Configuration
+public class DataSources {
+
+    @Bean @Primary
+    @ConfigurationProperties("spring.datasource.primary")
+    DataSource primaryDs() { return DataSourceBuilder.create().build(); }
+
+    @Bean @Qualifier("reporting")
+    @ConfigurationProperties("spring.datasource.reporting")
+    DataSource reportingDs() { return DataSourceBuilder.create().build(); }
+
+    @Bean @Qualifier("reporting")
+    NamedParameterJdbcTemplate reportingJdbc(@Qualifier("reporting") DataSource ds) {
+        return new NamedParameterJdbcTemplate(ds);
+    }
+}
+```
+
+```java
+public interface UserDaoQuery extends DaoQuery {
+    // no annotation → uses the @Primary datasource
+}
+
+@DaoQueryDataSource("reporting")
+public interface ReportingDaoQuery extends DaoQuery {
+    // routes to the @Qualifier("reporting") bean
+}
+```
+
+**Notes:**
+
+- The qualifier is class-level (one DAO ↔ one database). For two databases, define two DAO interfaces.
+- DAOs without `@DaoQueryDataSource` keep the previous behavior — unqualified `getBean` lookup, which finds the `@Primary` bean or the single match.
+- For transactions, use Spring's per-manager qualifier as usual: `@Transactional("reportingTxManager")` on the service method. The library doesn't manage transactions itself; it just resolves the right `EntityManager` so it participates in whatever transaction context Spring sets up.
+- Database vendor types may differ across qualifiers (e.g., PostgreSQL primary + Oracle reporting). The library is dialect-agnostic — you just write SQL appropriate for each target in its respective XML file.
+
 ## Handlebars helpers
 
 Templates are processed by Handlebars. Built-in helpers:
@@ -291,7 +333,6 @@ Templates are processed by Handlebars. Built-in helpers:
 | `{{#query queryType}}…{{/query}}` | Emit only when rendering the **data query** |
 | `{{#count queryType}}…{{/count}}` | Emit only when rendering the **count query** (used with `DaoQueryListResult`) |
 | `{{#return queryType}}…{{/return}}` | Emit only when rendering a **post-write return query** (e.g., fetch the row just inserted) |
-| `{{#dbType dbType "postgresql"}}…{{/dbType}}` | Conditional block per JDBC driver (case-insensitive). `dbType` is auto-parsed from `spring.datasource.url`. |
 | `{{#nullOrZero v}}…{{else}}…{{/nullOrZero}}` | Branch on null-or-zero |
 | `{{queryNullable v}}` | Render value, or empty string if `null` |
 

--- a/spring-dao/src/main/java/org/r3al/springdao/ApplicationContextProvider.java
+++ b/spring-dao/src/main/java/org/r3al/springdao/ApplicationContextProvider.java
@@ -1,5 +1,6 @@
 package org.r3al.springdao;
 
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Configuration;
@@ -8,11 +9,24 @@ import org.springframework.context.annotation.Configuration;
 public class ApplicationContextProvider implements ApplicationContextAware {
 
     private static ApplicationContext context;
- 
+
     public static ApplicationContext getApplicationContext() {
         return context;
     }
- 
+
+    /**
+     * Resolves a bean by type, optionally restricted to a Spring {@code @Qualifier}.
+     * When {@code qualifier} is null or blank, falls back to unqualified type lookup
+     * (which honours {@code @Primary}).
+     */
+    public static <T> T getBean(Class<T> type, String qualifier) {
+        if (qualifier == null || qualifier.isBlank()) {
+            return context.getBean(type);
+        }
+        return BeanFactoryAnnotationUtils.qualifiedBeanOfType(
+                context.getAutowireCapableBeanFactory(), type, qualifier);
+    }
+
     @Override
     public void setApplicationContext(ApplicationContext ctx) {
         context = ctx;

--- a/spring-dao/src/main/java/org/r3al/springdao/DaoQueryInfo.java
+++ b/spring-dao/src/main/java/org/r3al/springdao/DaoQueryInfo.java
@@ -44,6 +44,7 @@ public class DaoQueryInfo implements Serializable, Cloneable {
     private RowMapper<?> rowMapper;
     private boolean useRowMapper;
     private boolean useBatch;
+    private String qualifier;
 
     private DaoQueryInfo() {
     }
@@ -87,6 +88,10 @@ public class DaoQueryInfo implements Serializable, Cloneable {
 
         info.useBatch = method.isAnnotationPresent(DaoQueryBatch.class);
 
+        if (classe.isAnnotationPresent(DaoQueryDataSource.class)) {
+            info.qualifier = classe.getAnnotation(DaoQueryDataSource.class).value();
+        }
+
         return info;
     }
 
@@ -95,7 +100,6 @@ public class DaoQueryInfo implements Serializable, Cloneable {
         info.sqlCount = null;
         info.sqlReturn = null;
         info.parameterList = new ArrayList<>();
-        info.parameterList.add(info.parseDbType(PropertyUtil.getValue("spring.datasource.url", "jdbc:unknown")));
 
         for (int i = 0; i < invocation.getArguments().length; i++) {
             Object argument = invocation.getArguments()[i];
@@ -276,17 +280,6 @@ public class DaoQueryInfo implements Serializable, Cloneable {
         return this.returnType.getName().equals(DaoQueryListResult.class.getName());
     }
 
-    private DaoQueryParameter parseDbType(String jdbcUrl) {
-        final String regex = "\\:([a-zA-Z]+)";
-        final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
-        final Matcher matcher = pattern.matcher(jdbcUrl);
-
-        if (!matcher.find()) {
-            throw new RuntimeException("Couldn't identify database type");
-        }
-        return new DaoQueryParameter("dbType", matcher.group(1));
-    }
-
     public String getSqlPattern() {
         return this.sqlPattern.template;
     }
@@ -324,5 +317,9 @@ public class DaoQueryInfo implements Serializable, Cloneable {
 
     public boolean isBatch(){
         return useBatch;
+    }
+
+    public String getQualifier() {
+        return qualifier;
     }
 }

--- a/spring-dao/src/main/java/org/r3al/springdao/annotations/DaoQueryDataSource.java
+++ b/spring-dao/src/main/java/org/r3al/springdao/annotations/DaoQueryDataSource.java
@@ -1,0 +1,24 @@
+package org.r3al.springdao.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Routes a DaoQuery interface to a specific datasource by Spring bean qualifier.
+ * When present, the library resolves EntityManager / NamedParameterJdbcTemplate via
+ * {@code BeanFactoryAnnotationUtils.qualifiedBeanOfType} using the given qualifier
+ * instead of an unqualified lookup. When absent, falls back to the primary bean.
+ *
+ * <pre>{@code
+ * @DaoQueryDataSource("reporting")
+ * public interface ReportingDaoQuery extends DaoQuery { ... }
+ * }</pre>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DaoQueryDataSource {
+
+    String value();
+}

--- a/spring-dao/src/main/java/org/r3al/springdao/impl/DaoQueryMethodInterceptorImpl.java
+++ b/spring-dao/src/main/java/org/r3al/springdao/impl/DaoQueryMethodInterceptorImpl.java
@@ -37,7 +37,8 @@ public class DaoQueryMethodInterceptorImpl implements DaoQueryMethodInterceptor 
     }
 
     private Object executeWithJdbcTemplate(DaoQueryInfo info) throws IOException {
-        NamedParameterJdbcTemplate jdbcTemplate = ApplicationContextProvider.getApplicationContext().getBean(NamedParameterJdbcTemplate.class);
+        NamedParameterJdbcTemplate jdbcTemplate = ApplicationContextProvider.getBean(
+                NamedParameterJdbcTemplate.class, info.getQualifier());
 
         if (!info.isUseSqlInline()) {
             LOGGER.debug("loading template {}: {}", info.getSqlKey(), info.getSqlPattern());
@@ -131,7 +132,8 @@ public class DaoQueryMethodInterceptorImpl implements DaoQueryMethodInterceptor 
 
     private Object executeWithEntityManager(DaoQueryInfo info) throws IOException {
 
-        EntityManager entityManager = ApplicationContextProvider.getApplicationContext().getBean(EntityManager.class);
+        EntityManager entityManager = ApplicationContextProvider.getBean(
+                EntityManager.class, info.getQualifier());
         Session session = entityManager.unwrap(Session.class);
         NativeQuery<?> query;
 

--- a/spring-dao/src/main/java/org/r3al/springdao/templates/HandleBarTemplate.java
+++ b/spring-dao/src/main/java/org/r3al/springdao/templates/HandleBarTemplate.java
@@ -74,13 +74,6 @@ public class HandleBarTemplate {
             return "";
         }
 
-        public CharSequence dbType(String type, String value, Options options) throws IOException {
-            if (type.equalsIgnoreCase(value)) {
-                return options.fn();
-            }
-            return "";
-        }
-
         public CharSequence queryNullable(Object data, Options options) {
             return data == null ? "" : data.toString();
         }

--- a/spring-dao/src/test/java/org/r3al/springdao/DaoQueryInfoTest.java
+++ b/spring-dao/src/test/java/org/r3al/springdao/DaoQueryInfoTest.java
@@ -3,6 +3,7 @@ package org.r3al.springdao;
 import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.Test;
 import org.r3al.springdao.annotations.DaoQueryBatch;
+import org.r3al.springdao.annotations.DaoQueryDataSource;
 import org.r3al.springdao.annotations.DaoQuerySql;
 import org.r3al.springdao.annotations.DaoQueryUseJdbcTemplate;
 
@@ -144,5 +145,28 @@ class DaoQueryInfoTest {
         DaoQueryInfo info = DaoQueryInfo.of(SampleDao.class, invocationOf("withJdbc"));
 
         assertThat(info.isUseJdbcTemplate()).isTrue();
+    }
+
+    @Test
+    void qualifierIsNullWhenAnnotationAbsent() throws Exception {
+        DaoQueryInfo info = DaoQueryInfo.of(SampleDao.class, invocationOf("findAll"));
+
+        assertThat(info.getQualifier()).isNull();
+    }
+
+    @DaoQueryDataSource("reporting")
+    interface ReportingDao extends DaoQuery {
+        List<Bean> findAll();
+    }
+
+    @Test
+    void qualifierReadFromDaoQueryDataSourceAnnotation() throws Exception {
+        Method method = ReportingDao.class.getMethod("findAll");
+        MethodInvocation inv = mock(MethodInvocation.class);
+        when(inv.getMethod()).thenReturn(method);
+
+        DaoQueryInfo info = DaoQueryInfo.of(ReportingDao.class, inv);
+
+        assertThat(info.getQualifier()).isEqualTo("reporting");
     }
 }

--- a/spring-dao/src/test/java/org/r3al/springdao/templates/HandleBarTemplateTest.java
+++ b/spring-dao/src/test/java/org/r3al/springdao/templates/HandleBarTemplateTest.java
@@ -80,36 +80,6 @@ class HandleBarTemplateTest {
     }
 
     @Test
-    void dbTypeMatchEmitsBlock() throws IOException {
-        String out = render(
-                "{{#dbType dbType 'postgresql'}}PG-ONLY{{/dbType}}",
-                Map.of("dbType", "postgresql")
-        );
-
-        assertThat(out).contains("PG-ONLY");
-    }
-
-    @Test
-    void dbTypeMatchIsCaseInsensitive() throws IOException {
-        String out = render(
-                "{{#dbType dbType 'PostgreSQL'}}PG-ONLY{{/dbType}}",
-                Map.of("dbType", "postgresql")
-        );
-
-        assertThat(out).contains("PG-ONLY");
-    }
-
-    @Test
-    void dbTypeMismatchSuppressesBlock() throws IOException {
-        String out = render(
-                "{{#dbType dbType 'mysql'}}MYSQL{{/dbType}}",
-                Map.of("dbType", "postgresql")
-        );
-
-        assertThat(out).doesNotContain("MYSQL");
-    }
-
-    @Test
     void nullOrZeroFiresFnBranchWhenValueIsNull() throws IOException {
         Map<String, Object> ctx = new HashMap<>();
         ctx.put("v", null);


### PR DESCRIPTION
Resolves multi-datasource use cases where one application talks to more than one database. Add @DaoQueryDataSource(value) to route a DAO interface to a specific qualified EntityManager / NamedParameterJdbcTemplate bean. DAOs without the annotation keep current behavior (unqualified getBean, honors @Primary).

Drop the {{#dbType}} Handlebars helper and the auto-injected :dbType parameter. Its source was the global spring.datasource.url property, which silently routed to the wrong vendor on multi-DB apps. Vendor-specific SQL should now live in the per-datasource XML file.

Generated with AI assistance.